### PR TITLE
Centralize security and configuration

### DIFF
--- a/dark-entities-backend/app/api/auth.py
+++ b/dark-entities-backend/app/api/auth.py
@@ -11,15 +11,15 @@
 #     return {"msg": "User login endpoint"}
 
 import uuid
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import OAuth2PasswordRequestForm
 from sqlalchemy.orm import Session
-from passlib.context import CryptContext
 from jose import jwt
 from datetime import datetime, timedelta
 from app.models.user import User
 from app.schemas.user import UserCreate, UserRead
 from app.core.dependencies import get_db
+from app.core.security import get_password_hash, verify_password
 import os
 
 router = APIRouter()
@@ -27,14 +27,6 @@ router = APIRouter()
 SECRET_KEY = os.getenv("SECRET_KEY", "changeme")
 ALGORITHM = "HS256"
 ACCESS_TOKEN_EXPIRE_MINUTES = 60 * 24  # 1 día
-
-pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
-
-def get_password_hash(password):
-    return pwd_context.hash(password)
-
-def verify_password(plain, hashed):
-    return pwd_context.verify(plain, hashed)
 
 def create_access_token(data: dict, expires_delta: timedelta = None):
     to_encode = data.copy()

--- a/dark-entities-backend/app/database.py
+++ b/dark-entities-backend/app/database.py
@@ -1,7 +1,6 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+from app.core.config import settings
 
-SQLALCHEMY_DATABASE_URL = "postgresql://postgres:elsaye@localhost/darkentities"
-
-engine = create_engine(SQLALCHEMY_DATABASE_URL)
+engine = create_engine(settings.DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/dark-entities-backend/app/schemas/user.py
+++ b/dark-entities-backend/app/schemas/user.py
@@ -1,14 +1,16 @@
 from pydantic import BaseModel, EmailStr
 from typing import Optional
 
+
 class UserCreate(BaseModel):
-    _id: Optional[int]
+    id: Optional[str] = None
     email: EmailStr
     password: str
     role: Optional[str] = "user"   # Solo para admin
 
+
 class UserRead(BaseModel):
-    _id: Optional[int]
+    id: Optional[str] = None
     email: EmailStr
     role: str
 

--- a/dark-entities-frontend/src/api/auth.ts
+++ b/dark-entities-frontend/src/api/auth.ts
@@ -1,4 +1,5 @@
 import axios from "axios";
+import { API_BASE_URL } from "./config";
 
 export const login = async (email: string, password: string) => {
   const data = new URLSearchParams();
@@ -6,7 +7,7 @@ export const login = async (email: string, password: string) => {
   data.append("password", password);
 
   const res = await axios.post(
-    "http://127.0.0.1:8000/auth/login",
+    `${API_BASE_URL}/auth/login`,
     data,
     {
       headers: {
@@ -19,7 +20,7 @@ export const login = async (email: string, password: string) => {
 
 export const register = async (email: string, password: string) => {
   const res = await axios.post(
-    "http://127.0.0.1:8000/auth/register",
+    `${API_BASE_URL}/auth/register`,
     { email, password },
     { headers: { "Content-Type": "application/json" } }
   );

--- a/dark-entities-frontend/src/api/config.ts
+++ b/dark-entities-frontend/src/api/config.ts
@@ -1,0 +1,2 @@
+export const API_BASE_URL =
+  import.meta.env.VITE_API_BASE_URL || "http://127.0.0.1:8000";

--- a/dark-entities-frontend/src/components/DashboardLayout.tsx
+++ b/dark-entities-frontend/src/components/DashboardLayout.tsx
@@ -12,13 +12,7 @@ import {
 } from "@mui/material";
 import { Event, ConfirmationNumber, Logout, Group } from "@mui/icons-material";
 import { useNavigate } from "react-router-dom";
-
-// Hook simple para obtener el rol actual
-function useCurrentUser() {
-  const role = localStorage.getItem("role");
-  const token = localStorage.getItem("token");
-  return { role, token };
-}
+import { useCurrentUser } from "../hooks/useCurrentUser";
 
 export default function DashboardLayout({ children }: { children: React.ReactNode }) {
   const navigate = useNavigate();


### PR DESCRIPTION
## Summary
- Align user schema with model ID naming and types
- Centralize password hashing via core security utilities
- Read database URL and API base URL from configuration
- Reuse global `useCurrentUser` hook in dashboard layout

## Testing
- `pytest` (no tests discovered)
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_689398d223c4832fb571766971db01dc